### PR TITLE
Add catalog-info.yaml for Mattermost Backstage Portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: elrond
+  annotations:
+    github.com/project-slug: mattermost/elrond
+    backstage.io/adr-location: docs/adrs
+spec:
+  type: "service"
+  system: "cloud-services"
+  lifecycle: "production"
+  owner: "cloud-sre"


### PR DESCRIPTION
#### Summary
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the Mattermost Backstage App software catalog

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).

