### PR TITLE
force unlock group when it is stuck in release-pending state

### DIFF
--- a/internal/supervisor/installationgroup.go
+++ b/internal/supervisor/installationgroup.go
@@ -379,22 +379,6 @@ func (s *InstallationGroupSupervisor) forceUnlockStaleLocks(logger log.FieldLogg
 
 // checkLegitimateWait checks if there are valid reasons for a group to be in release-pending state
 func (s *InstallationGroupSupervisor) checkLegitimateWait(group *model.InstallationGroup, logger log.FieldLogger) (bool, error) {
-	// Check if ring is in correct state
-	ring, err := s.store.GetRingFromInstallationGroupID(group.ID)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to get ring for installation group")
-	}
-
-	// If ring is not in a state that allows release, legitimately pending
-	if ring.State != model.RingStateReleaseRequested && ring.State != model.RingStateReleaseInProgress {
-		logger.WithFields(log.Fields{
-			"installationGroupID": group.ID,
-			"ringState":           ring.State,
-			"action":              "waiting_for_ring_state",
-		}).Debug("Group is legitimately waiting for ring state")
-		return true, nil
-	}
-
 	// Check if waiting for other groups in progress
 	inProgressGroups, err := s.store.GetInstallationGroupsReleaseInProgress()
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
#### Fix Stuck Installation Group Locks in Release-Pending State
We encountered a critical issue where installation groups could become permanently stuck in `release-pending` state due to stale locks held by different Elrond instances. This created a deadlock scenario where:
- Ring state: `release-in-progress`
- Installation group state: `release-pending`
- Lock status: Held by a different instance (ewkoib5yf78ff88hsrbykaxcdo)
- Result: Release process completely halted, requiring manual intervention

#### Root Cause Analysis
The issue stemmed from several factors:
1. Stale Locks: When an Elrond instance crashes or becomes unresponsive, it leaves installation group locks in the database
2. No Automatic Cleanup: The system had no mechanism to detect and clear stale locks
3. Manual Resolution Required: We had to manually execute SQL commands to clear locks

#### Why This Happens
The state transition logic creates a deadlock:
1. Ring goes to `release-in-progress` ✅
2. Installation Group should move from `release-pending` → `release-requested` ❌
3. But it can't because it's locked by the old instance
4. So it stays in `release-pending` forever
5. Ring stays in `release-in-progress` waiting for all groups to complete

#### Real example
```
{"instance":"49xr7hk5mjg4jfi83t7g37gjqe","level":"info","msg":"There are installation groups pending work...","ring":"nzy7qjxxnz71jnnhwxxxx","time":"2025-08-06T14:39:01Z"}
```
```
+--------------------------+----+---------------+-------------------+--------+--------------------------+--------------------------+--------------+
|id                        |name|state          |releaseat          |soaktime|provisionergroupid        |lockacquiredby            |lockacquiredat|
+--------------------------+----+---------------+-------------------+--------+--------------------------+--------------------------+--------------+
|ywixxx6iqbn85e5qozoyorxxxxr|cws |release-pending|1750411592573003950|0       |ayx861wdbjri9qrtyiwxxxxx|ewkoib5yf78ff88hsrbykaxcdo|1751012398165 |
+--------------------------+----+---------------+-------------------+--------+--------------------------+--------------------------+--------------+
```
The installation group is locked by Elrond instance `ewkoib5yf78ff88hsrbykaxcdo`, but the current instance is `49xr7hk5mjg4jfi83t7g37gjqe`.

#### Deadlock Scenario
Here's exactly what happened in your case:
```text
Time 0:    Instance A acquires lock for group X
Time 1:    Instance A crashes/becomes unresponsive
Time 2:    Lock remains in database (lock_acquired_by = "instance-A")
Time 3:    Instance B tries to supervise group X
Time 4:    Instance B calls TryLock() → Returns false (lock held by instance A)
Time 5:    Instance B skips group X (function returns early)
Time 6:    Group X stays in release-pending forever
Time 7:    Ring stays in release-in-progress forever
```

#### Solution: Intelligent Lock Cleanup with Legitimate Wait Detection
We implemented a lock cleanup mechanism that:
1. Detects Legitimate Waits: Only unlocks groups that have no valid reason to be pending
2. Respects Sequential Releases: Allows groups to wait for others in the release sequence
3. Safe: Won't interrupt legitimate operations in progress
4. Automatic: Runs every 30 seconds as part of the supervision cycle

#### Why Legitimate Wait Detection is Critical
- `release-pending` groups can legitimately wait for extended periods when:
- Sequential Releases: Group 2 waits for Group 1 to complete (could take 30+ minutes)
- Ring State: Waiting for ring to reach the correct state
- Other Groups: Waiting for other groups to finish their work

#### What Happens After Unlock
1. Lock is unlocked automatically
2. Your instance acquires lock
3. Group transitions `release-pending` → `release-requested`
4. Group calls provisioner and updates installations
7. Ring moves `release-in-progress` → `soaking-requested`
8. Release completes successfully

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9479

